### PR TITLE
Eak adjust  winning coach and worst coach methods

### DIFF
--- a/data/season_game_sample.csv
+++ b/data/season_game_sample.csv
@@ -9,4 +9,4 @@ game_id,season,type,date_time,away_team_id,home_team_id,away_goals,home_goals,ve
 2012030313,20122013,Postseason,6/6/13,5,6,1,2,Toyota Stadium,/api/v1/venues/null
 2012030314,20122013,Postseason,6/8/13,5,6,0,1,Toyota Stadium,/api/v1/venues/null
 2012030231,20122013,Postseason,5/16/13,17,16,1,2,Gillette Stadium,/api/v1/venues/null
-2013030152,20132014,Postseason,4/20/14,30,21,2,2,BC Place,/api/v1/venues/null
+2013030152,20122013,Postseason,4/20/14,30,21,2,2,BC Place,/api/v1/venues/null

--- a/data/season_game_sample.csv
+++ b/data/season_game_sample.csv
@@ -9,3 +9,4 @@ game_id,season,type,date_time,away_team_id,home_team_id,away_goals,home_goals,ve
 2012030313,20122013,Postseason,6/6/13,5,6,1,2,Toyota Stadium,/api/v1/venues/null
 2012030314,20122013,Postseason,6/8/13,5,6,0,1,Toyota Stadium,/api/v1/venues/null
 2012030231,20122013,Postseason,5/16/13,17,16,1,2,Gillette Stadium,/api/v1/venues/null
+2013030152,20132014,Postseason,4/20/14,30,21,2,2,BC Place,/api/v1/venues/null

--- a/data/season_game_teams_sample.csv
+++ b/data/season_game_teams_sample.csv
@@ -19,3 +19,5 @@ game_id,team_id,hoa,result,settled_in,head_coach,goals,shots,tackles,pim,powerPl
 2012030314,6,home,WIN,REG,Claude Julien,1,6,25,8,3,0,52.5,11,5
 2012030231,17,away,LOSS,REG,Mike Babcock,1,5,43,10,3,0,52.5,6,4
 2012030231,16,home,WIN,REG,Joel Quenneville,2,10,24,10,3,1,47.5,2,11
+2013030152,30,away,TIE,REG,Mike Yeo,2,8,34,16,3,0,52.2,3,7
+2013030152,21,home,TIE,REG,Patrick Roy,2,7,26,16,3,1,47.8,3,9

--- a/lib/game_team_manager.rb
+++ b/lib/game_team_manager.rb
@@ -19,6 +19,13 @@ class GameTeamManager
     end
   end
 
+  def tied?(game_id)
+    game_results = by_game_id(game_id).map do |game_team|
+      game_team.result
+    end
+    game_results.include?("TIE")
+  end
+
   def coaches(season_game_ids)
     season_game_ids.flat_map do |game_id|
       game_team_pair = by_game_id(game_id)
@@ -38,14 +45,16 @@ class GameTeamManager
 
   def winning_coach(game_id)
     winner = by_game_id(game_id).find do |game_team|
-        game_team.result == "WIN"
-      end
+      game_team.result == "WIN"
+    end
     winner.head_coach
   end
 
   def winning_coaches(season_game_ids)
     season_game_ids.map do |game|
-      winning_coach(game)
+      if !tied?(game)
+        winning_coach(game)
+      end
     end
   end
 

--- a/lib/game_team_manager.rb
+++ b/lib/game_team_manager.rb
@@ -26,50 +26,50 @@ class GameTeamManager
     game_results.include?("TIE")
   end
 
-  def coaches(season_game_ids)
-    season_game_ids.flat_map do |game_id|
-      game_team_pair = by_game_id(game_id)
-      game_team_pair.map do |game_team|
+  def coaches(game_ids)
+    game_ids.flat_map do |game_id|
+      by_game_id(game_id).flat_map do |game_team|
         game_team.head_coach
       end
-    end
+    end.uniq
   end
 
-  def coach_wins(season_game_ids)
-    coach_results = {}
-    coaches(season_game_ids).uniq.each do |coach|
-      coach_results[coach] = winning_coaches(season_game_ids).count(coach)
+  def by_coach(game_ids, coach)
+    all = game_ids.flat_map do |game_id|
+      by_game_id(game_id)
     end
-    coach_results
+    filtered = all.filter do |game_team|
+      game_team.head_coach == coach
+    end
+    filtered
   end
 
-  def winning_coach(game_id)
-    winner = by_game_id(game_id).find do |game_team|
+  def wins(collection)
+    collection.count do |game_team|
       game_team.result == "WIN"
     end
-    winner.head_coach
   end
 
-  def winning_coaches(season_game_ids)
-    season_game_ids.map do |game|
-      if !tied?(game)
-        winning_coach(game)
-      end
+  def total_games(collection)
+    collection.count
+  end
+
+  def win_percentage(collection)
+    (wins(collection) / total_games(collection).to_f * 100).round(2)
+  end
+
+  def winningest_coach(game_ids)
+    winningest = coaches(game_ids).max_by do |coach|
+      win_percentage(by_coach(game_ids, coach))
     end
+    winningest
   end
 
-  def winningest_coach(season_game_ids)
-    winningest = coach_wins(season_game_ids).max_by do |coach, wins|
-      wins.to_f / coaches(season_game_ids).count(coach) * 100
-    end # returns array [coach_name, win_count]
-    winningest[0] #coach name will be index 0
-  end
-
-  def worst_coach(season_game_ids)
-    worst = coach_wins(season_game_ids).min_by do |coach, wins|
-      wins.to_f / coaches(season_game_ids).count(coach) * 100
+  def worst_coach(game_ids)
+    worst_team = coaches(game_ids).min_by do |coach|
+      win_percentage(by_coach(game_ids, coach))
     end
-    worst[0]
+    worst_team
   end
 
   def total_shots(team_id)

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -40,12 +40,12 @@ class StatTracker
   end
 
   def winningest_coach(season)
-    season_games = @season_manager.game_id_by_season(season) #returns array of game ids
+    season_games = @season_manager.game_id_by_season(season)
     @game_team_manager.winningest_coach(season_games)
   end
 
   def worst_coach(season)
-    season_games = @season_manager.game_id_by_season(season) #returns array of game ids
+    season_games = @season_manager.game_id_by_season(season)
     @game_team_manager.worst_coach(season_games)
   end
 

--- a/spec/game_team_manager_spec.rb
+++ b/spec/game_team_manager_spec.rb
@@ -49,14 +49,14 @@ RSpec.describe GameTeamManager do
     expect(@game_team_manager.winning_coach('2012030221')).to eq('Claude Julien')
   end
 
-  xit 'can find winning coaches' do
+  it 'can find winning coaches' do
     results = ["Claude Julien", "Claude Julien", "Claude Julien", "Claude Julien",
       "Claude Julien", "Claude Julien", "Claude Julien", "Claude Julien", "Claude Julien", "Joel Quenneville"]
 
     expect(@game_team_manager.winning_coaches(@season_game_ids)).to eq(results)
   end
 
-  xit 'has results for each coach in a season' do
+  it 'has results for each coach in a season' do
     results = {"Claude Julien"=>9,
                "Dan Bylsma"=>0,
                "Joel Quenneville"=>1,
@@ -66,11 +66,11 @@ RSpec.describe GameTeamManager do
     expect(@game_team_manager.coach_wins(@season_game_ids)).to eq(results)
   end
 
-  xit 'has winningest_coach by season' do
+  it 'has winningest_coach by season' do
     expect(@game_team_manager.winningest_coach(@season_game_ids)).to eq("Claude Julien")
   end
 
-  xit 'has worst coach by season' do
+  it 'has worst coach by season' do
     expect(@game_team_manager.worst_coach(@season_game_ids)).to eq("John Tortorella")
   end
 

--- a/spec/game_team_manager_spec.rb
+++ b/spec/game_team_manager_spec.rb
@@ -29,7 +29,11 @@ RSpec.describe GameTeamManager do
     expect(@game_team_manager.by_game_id('2012030221')).to be_an(Array)
     expect(@game_team_manager.by_game_id('2012030221').count).to eq(2)
     expect(@game_team_manager.by_game_id('2012030221')[0]).to be_a(GameTeam)
+  end
 
+  it 'tied?' do
+    expect(@game_team_manager.tied?('2012030221')).to eq(false)
+    expect(@game_team_manager.tied?('2013030152')).to eq(true)
   end
 
   it 'has coaches' do
@@ -45,14 +49,14 @@ RSpec.describe GameTeamManager do
     expect(@game_team_manager.winning_coach('2012030221')).to eq('Claude Julien')
   end
 
-  it 'can find winning coaches' do
+  xit 'can find winning coaches' do
     results = ["Claude Julien", "Claude Julien", "Claude Julien", "Claude Julien",
       "Claude Julien", "Claude Julien", "Claude Julien", "Claude Julien", "Claude Julien", "Joel Quenneville"]
 
     expect(@game_team_manager.winning_coaches(@season_game_ids)).to eq(results)
   end
 
-  it 'has results for each coach in a season' do
+  xit 'has results for each coach in a season' do
     results = {"Claude Julien"=>9,
                "Dan Bylsma"=>0,
                "Joel Quenneville"=>1,
@@ -62,11 +66,11 @@ RSpec.describe GameTeamManager do
     expect(@game_team_manager.coach_wins(@season_game_ids)).to eq(results)
   end
 
-  it 'has winningest_coach by season' do
+  xit 'has winningest_coach by season' do
     expect(@game_team_manager.winningest_coach(@season_game_ids)).to eq("Claude Julien")
   end
 
-  it 'has worst coach by season' do
+  xit 'has worst coach by season' do
     expect(@game_team_manager.worst_coach(@season_game_ids)).to eq("John Tortorella")
   end
 
@@ -118,7 +122,9 @@ RSpec.describe GameTeamManager do
     results = {
       "16"=>[2],
       "17"=>[1],
+      "21"=> [2],
       "3"=>[2, 2, 1, 2, 1],
+      "30"=> [2],
       "5"=>[0, 1, 1, 0],
       "6"=>[3, 3, 2, 3, 3, 3, 4, 2, 1]
     }
@@ -129,7 +135,9 @@ RSpec.describe GameTeamManager do
     results = {
       "16"=>2.0,
       "17"=>1.0,
+      "21"=> 2.0,
       "3"=>1.6,
+      "30"=> 2.0,
       "5"=>0.5,
       "6"=>2.66
     }

--- a/spec/game_team_manager_spec.rb
+++ b/spec/game_team_manager_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe GameTeamManager do
     }
     @game_team_manager = GameTeamManager.new(locations)
     @season_game_ids = ['2012030221', '2012030222', '2012030223', '2012030224', '2012030225',
-      '2012030311', '2012030312', '2012030313', '2012030314', '2012030231']
-    @season_team_ids = ['3', '6', '5', '17', '16']
+      '2012030311', '2012030312', '2012030313', '2012030314', '2012030231', '2013030152']
+    @season_team_ids = ['3', '6', '5', '17', '16', '30', '21']
   end
 
   it "exists" do
@@ -36,34 +36,36 @@ RSpec.describe GameTeamManager do
     expect(@game_team_manager.tied?('2013030152')).to eq(true)
   end
 
+  it 'counts wins for given collection' do
+    collection = @season_game_ids.flat_map do |game_id|
+                   @game_team_manager.by_game_id(game_id)
+                 end
+    expect(@game_team_manager.wins(collection)).to eq(10)
+  end
+
+  it 'total games for given team id' do
+    collection = @season_game_ids.flat_map do |game_id|
+                   @game_team_manager.by_game_id(game_id)
+                 end
+    expect(@game_team_manager.total_games(collection)).to eq(22)
+  end
+
+  it 'calculates win percentage' do
+    collection = @season_game_ids.flat_map do |game_id|
+                   @game_team_manager.by_game_id(game_id)
+                 end
+    expect(@game_team_manager.win_percentage(collection)).to eq(45.45)
+  end
+
   it 'has coaches' do
-    results = ["John Tortorella", "Claude Julien", "John Tortorella", "Claude Julien",
-      "Claude Julien", "John Tortorella", "Claude Julien", "John Tortorella",
-      "John Tortorella", "Claude Julien", "Claude Julien", "Dan Bylsma", "Claude Julien",
-      "Dan Bylsma", "Dan Bylsma", "Claude Julien", "Dan Bylsma", "Claude Julien", "Mike Babcock", "Joel Quenneville"]
-
-    expect(@game_team_manager.coaches(@season_game_ids)).to eq(results)
+    result = ["John Tortorella", "Claude Julien", "Dan Bylsma", "Mike Babcock", "Joel Quenneville", "Mike Yeo", "Patrick Roy"]
+    expect(@game_team_manager.coaches(@season_game_ids)).to eq(result)
   end
 
-  it 'can find winning coach' do
-    expect(@game_team_manager.winning_coach('2012030221')).to eq('Claude Julien')
-  end
-
-  it 'can find winning coaches' do
-    results = ["Claude Julien", "Claude Julien", "Claude Julien", "Claude Julien",
-      "Claude Julien", "Claude Julien", "Claude Julien", "Claude Julien", "Claude Julien", "Joel Quenneville"]
-
-    expect(@game_team_manager.winning_coaches(@season_game_ids)).to eq(results)
-  end
-
-  it 'has results for each coach in a season' do
-    results = {"Claude Julien"=>9,
-               "Dan Bylsma"=>0,
-               "Joel Quenneville"=>1,
-               "John Tortorella"=>0,
-               "Mike Babcock"=>0
-              }
-    expect(@game_team_manager.coach_wins(@season_game_ids)).to eq(results)
+  it 'has game_teams by a given coach' do
+    expect(@game_team_manager.by_coach(@season_game_ids, "Claude Julien")).to be_an(Array)
+    expect(@game_team_manager.by_coach(@season_game_ids, "Claude Julien").count).to eq(9)
+    expect(@game_team_manager.by_coach(@season_game_ids, "Claude Julien")[0]).to be_a(GameTeam)
   end
 
   it 'has winningest_coach by season' do
@@ -91,7 +93,9 @@ RSpec.describe GameTeamManager do
   it 'has accuracy for each team' do
     results = {"16"=>5.0,
                "17"=>5.0,
+               "21"=>3.5,
                "3"=>4.75,
+               "30"=>4.0,
                "5"=>16.0,
                "6"=>3.17
               }

--- a/spec/season_manager_spec.rb
+++ b/spec/season_manager_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe SeasonManager do
 
   it 'gets games for given season' do
     expect(@season_manager.games_in_season('20122013')[0]).to be_a(Game)
-    expect(@season_manager.games_in_season('20122013').count).to eq(10)
+    expect(@season_manager.games_in_season('20122013').count).to eq(11)
   end
 
   it 'can extract game id' do
@@ -36,13 +36,14 @@ RSpec.describe SeasonManager do
       '2012030312',
       '2012030313',
       '2012030314',
-      '2012030231'
+      '2012030231',
+      '2013030152'
       ]
     expect(@season_manager.game_id_by_season('20122013')).to eq(result)
   end
 
   it 'can extract team ids' do
-    result = ['3', '6', '5', '17', '16']
+    result = ['3', '6', '5', '17', '16', '30', '21']
     expect(@season_manager.team_id_by_season('20122013')).to eq(result)
   end
 end


### PR DESCRIPTION
adjust winning coach and worst coach to work with full data set and pass spec harness 

notes: cannot access info by season via team ids - will cause methods to collect GameTeam objects from different seasons

teams have multiple different coaches per season